### PR TITLE
Load cl.el at compile time for using lexical-let

### DIFF
--- a/unison.el
+++ b/unison.el
@@ -30,6 +30,8 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'cl))
 
 (defgroup unison nil
   "For syncing files with Unison"


### PR DESCRIPTION
This PR fixes following byte-compile warnings.

```
In unison:
unison.el:55:4:Warning: ‘(proc (apply (function start-process) "Unison"
    "*unison*" unison-program unison-args))’ is a malformed function
unison.el:60:27:Warning: reference to free variable ‘proc’
unison.el:70:46:Warning: reference to free variable ‘buffer-displayed’
unison.el:72:46:Warning: assignment to free variable ‘buffer-displayed’

In end of data:
unison.el:80:1:Warning: the following functions are not known to be defined: lexical-let,
    buffer-displayed
```
